### PR TITLE
Version bump for SixLabors.ImageSharp

### DIFF
--- a/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
+++ b/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
@@ -4,7 +4,7 @@
     <PackageId>Mii.SixLaborsCaptcha.Core</PackageId>
     <AssemblyName>Mii.SixLaborsCaptcha.Core</AssemblyName>
     <RootNamespace>Mii.SixLaborsCaptcha.Core</RootNamespace>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/firstyuyu/SixLaborsCaptcha</RepositoryUrl>
     <PackageDescription>Forked the original repository to address vulnerable dependencies</PackageDescription>

--- a/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
+++ b/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
@@ -9,8 +9,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
+++ b/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <AssemblyName>SixLaborsCaptcha.Core</AssemblyName>
-    <RootNamespace>SixLaborsCaptcha.Core</RootNamespace>
-    <Version>1.0.0</Version>
-    <RepositoryUrl>https://github.com/aliasadidev/SixLaborsCaptcha</RepositoryUrl>
-    <PackageDescription>Generate captcha with SixLabors' libraries on .NET Core (run in both Windows and Linux environments)</PackageDescription>
+    <PackageId>Mii.SixLaborsCaptcha.Core</PackageId>
+    <AssemblyName>Mii.SixLaborsCaptcha.Core</AssemblyName>
+    <RootNamespace>Mii.SixLaborsCaptcha.Core</RootNamespace>
+    <Version>1.0.4</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/firstyuyu/SixLaborsCaptcha</RepositoryUrl>
+    <PackageDescription>Forked the original repository to address vulnerable dependencies</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
@@ -13,6 +15,6 @@
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
+++ b/src/SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SixLaborsCaptcha.Core/publish.sh
+++ b/src/SixLaborsCaptcha.Core/publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PROJECT_NAME=SixLaborsCaptcha.Core
+
+PAKCAGE_ID=$(cat $PROJECT_NAME.csproj | egrep 'PackageId' | sed -E 's/^.+<.+>([^<]+).+/\1/g')
+VERSION=$(cat $PROJECT_NAME.csproj | egrep '<Version>' | sed -E 's/^.+<.+>([^<]+).+/\1/g')
+
+echo "NuGet API Key: "
+read -s API_KEY
+
+echo "Building the project..."
+dotnet build --configuration Release
+
+if [[ $? -gt 0 ]]; then
+    exit $?
+fi
+
+echo ""
+echo "Publishing the library to NuGet"
+cd bin/Release
+dotnet nuget push "$PAKCAGE_ID.$VERSION.nupkg" -k $API_KEY -s https://api.nuget.org/v3/index.json
+cd ../..

--- a/src/SixLaborsCaptcha.Mvc.Core/SixLaborsCaptcha.Mvc.Core.csproj
+++ b/src/SixLaborsCaptcha.Mvc.Core/SixLaborsCaptcha.Mvc.Core.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.0.0</Version>
-    <RepositoryUrl>https://github.com/aliasadidev/SixLaborsCaptcha</RepositoryUrl>
-    <PackageDescription>Generate captcha with SixLabors' libraries on ASP.NET Core MVC (run in both Windows and Linux environments)</PackageDescription>
+    <PackageId>Mii.SixLaborsCaptcha.Mvc.Core</PackageId>
+    <Version>1.0.4</Version>
+    <AssemblyName>Mii.SixLaborsCaptcha.Mvc.Core</AssemblyName>
+    <RootNamespace>Mii.SixLaborsCaptcha.Mvc.Core</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/firstyuyu/SixLaborsCaptcha</RepositoryUrl>
+    <PackageDescription>Forked the original repository to address vulnerable dependencies</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
@@ -11,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.*" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SixLaborsCaptcha.Core\SixLaborsCaptcha.Core.csproj" />
+    <ProjectReference Include="../SixLaborsCaptcha.Core/SixLaborsCaptcha.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/SixLaborsCaptcha.Mvc.Core/SixLaborsCaptcha.Mvc.Core.csproj
+++ b/src/SixLaborsCaptcha.Mvc.Core/SixLaborsCaptcha.Mvc.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Mii.SixLaborsCaptcha.Mvc.Core</PackageId>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <AssemblyName>Mii.SixLaborsCaptcha.Mvc.Core</AssemblyName>
     <RootNamespace>Mii.SixLaborsCaptcha.Mvc.Core</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/SixLaborsCaptcha.Mvc.Core/publish.sh
+++ b/src/SixLaborsCaptcha.Mvc.Core/publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PROJECT_NAME=SixLaborsCaptcha.Mvc.Core
+
+PAKCAGE_ID=$(cat $PROJECT_NAME.csproj | egrep 'PackageId' | sed -E 's/^.+<.+>([^<]+).+/\1/g')
+VERSION=$(cat $PROJECT_NAME.csproj | egrep '<Version>' | sed -E 's/^.+<.+>([^<]+).+/\1/g')
+
+echo "NuGet API Key: "
+read -s API_KEY
+
+echo "Building the project..."
+dotnet build --configuration Release
+
+if [[ $? -gt 0 ]]; then
+    exit $?
+fi
+
+echo ""
+echo "Publishing the library to NuGet"
+cd bin/Release
+dotnet nuget push "$PAKCAGE_ID.$VERSION.nupkg" -k $API_KEY -s https://api.nuget.org/v3/index.json
+cd ../..


### PR DESCRIPTION
There is a warning visible when compiling on .NET 9: warning NU1902: Package 'SixLabors.ImageSharp' 3.1.3 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-5x7m-6737-26cr